### PR TITLE
Add gradient boosting comparison notebook

### DIFF
--- a/Gradient_Boosting_Comparison.ipynb
+++ b/Gradient_Boosting_Comparison.ipynb
@@ -1,0 +1,291 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Compara\u00e7\u00e3o de Gradient Boosting com e sem features qu\u00e2nticas\n",
+        "\n",
+        "Este notebook carrega os *folds* dispon\u00edveis na pasta `features/`, treina modelos de Gradient Boosting usando apenas as features cl\u00e1ssicas (`class_0` a `class_12`) e o conjunto combinado de features cl\u00e1ssicas + qu\u00e2nticas (`qf_0` a `qf_12`). Em seguida, comparamos o desempenho entre os dois cen\u00e1rios e geramos as predi\u00e7\u00f5es solicitadas.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Depend\u00eancias\n",
+        "\n",
+        "O notebook utiliza `pandas`, `numpy`, `scikit-learn`, `matplotlib` e `seaborn`. Caso ainda n\u00e3o as tenha instalado no seu ambiente, execute o comando abaixo em uma c\u00e9lula separada ou diretamente no terminal:\n",
+        "\n",
+        "```bash\n",
+        "pip install pandas numpy scikit-learn matplotlib seaborn\n",
+        "```\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "import seaborn as sns\n",
+        "from matplotlib import pyplot as plt\n",
+        "from sklearn.ensemble import GradientBoostingClassifier\n",
+        "from sklearn.metrics import (\n",
+        "    balanced_accuracy_score,\n",
+        "    f1_score,\n",
+        "    precision_score,\n",
+        "    recall_score,\n",
+        "    roc_auc_score,\n",
+        ")\n",
+        "\n",
+        "# Configura\u00e7\u00e3o est\u00e9tica padr\u00e3o para os gr\u00e1ficos\n",
+        "sns.set_style(\"whitegrid\")\n",
+        "plt.rcParams.update({\"figure.figsize\": (10, 5), \"axes.titlesize\": 14, \"axes.labelsize\": 12})\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Carregamento dos dados\n",
+        "\n",
+        "Cada CSV em `features/` corresponde a um *fold*. O conjunto possui uma coluna `set` indicando se a amostra pertence ao treino ou ao teste.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "data_dir = Path(\"features\")\n",
+        "fold_paths = sorted(data_dir.glob(\"features_y_fold*.csv\"))\n",
+        "if not fold_paths:\n",
+        "    raise FileNotFoundError(\"Nenhum arquivo `features_y_fold*.csv` foi encontrado na pasta `features/`.\")\n",
+        "\n",
+        "fold_frames = []\n",
+        "for path in fold_paths:\n",
+        "    frame = pd.read_csv(path)\n",
+        "    frame[\"fold_name\"] = path.stem\n",
+        "    fold_frames.append(frame)\n",
+        "\n",
+        "fold_summary = (\n",
+        "    pd.concat(\n",
+        "        [df.assign(set=df[\"set\"].str.lower())[[\"fold\", \"fold_name\", \"set\"]] for df in fold_frames],\n",
+        "        ignore_index=True,\n",
+        "    )\n",
+        "    .value_counts()\n",
+        "    .unstack(fill_value=0)\n",
+        ")\n",
+        "fold_summary\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Defini\u00e7\u00e3o dos grupos de features e fun\u00e7\u00e3o de avalia\u00e7\u00e3o\n",
+        "\n",
+        "A fun\u00e7\u00e3o abaixo treina um `GradientBoostingClassifier` para cada conjunto de features em todos os *folds*, calcula as m\u00e9tricas desejadas no conjunto de teste e armazena as predi\u00e7\u00f5es geradas.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "classical_features = [col for col in fold_frames[0].columns if col.startswith(\"class_\")]\n",
+        "quantum_features = [col for col in fold_frames[0].columns if col.startswith(\"qf_\")]\n",
+        "\n",
+        "feature_sets = {\n",
+        "    \"Benchmark\": classical_features,\n",
+        "    \"Quantum\": classical_features + quantum_features,\n",
+        "}\n",
+        "\n",
+        "metric_functions = {\n",
+        "    \"AUC\": lambda y_true, y_score, y_pred: roc_auc_score(y_true, y_score) if len(np.unique(y_true)) > 1 else np.nan,\n",
+        "    \"F1 Score Overall\": lambda y_true, y_score, y_pred: f1_score(y_true, y_pred),\n",
+        "    \"Balanced Accuracy\": lambda y_true, y_score, y_pred: balanced_accuracy_score(y_true, y_pred),\n",
+        "    \"Precision Class 0\": lambda y_true, y_score, y_pred: precision_score(y_true, y_pred, pos_label=0),\n",
+        "    \"Precision Class 1\": lambda y_true, y_score, y_pred: precision_score(y_true, y_pred, pos_label=1),\n",
+        "    \"Recall Class 0\": lambda y_true, y_score, y_pred: recall_score(y_true, y_pred, pos_label=0),\n",
+        "    \"Recall Class 1\": lambda y_true, y_score, y_pred: recall_score(y_true, y_pred, pos_label=1),\n",
+        "}\n",
+        "\n",
+        "results = []\n",
+        "prediction_frames = []\n",
+        "\n",
+        "for fold_idx, fold_df in enumerate(fold_frames):\n",
+        "    train_df = fold_df[fold_df[\"set\"] == \"train\"]\n",
+        "    test_df = fold_df[fold_df[\"set\"] == \"test\"]\n",
+        "\n",
+        "    y_train = train_df[\"y\"]\n",
+        "    y_test = test_df[\"y\"]\n",
+        "\n",
+        "    for label, columns in feature_sets.items():\n",
+        "        X_train = train_df[columns]\n",
+        "        X_test = test_df[columns]\n",
+        "\n",
+        "        model = GradientBoostingClassifier(random_state=42)\n",
+        "        model.fit(X_train, y_train)\n",
+        "\n",
+        "        y_proba = model.predict_proba(X_test)[:, 1]\n",
+        "        y_pred = model.predict(X_test)\n",
+        "\n",
+        "        for metric_name, metric_fn in metric_functions.items():\n",
+        "            value = metric_fn(y_test, y_proba, y_pred)\n",
+        "            results.append(\n",
+        "                {\n",
+        "                    \"fold\": fold_idx,\n",
+        "                    \"fold_name\": fold_df[\"fold_name\"].iat[0],\n",
+        "                    \"model\": label,\n",
+        "                    \"metric\": metric_name,\n",
+        "                    \"value\": value,\n",
+        "                }\n",
+        "            )\n",
+        "\n",
+        "        prediction_frames.append(\n",
+        "            pd.DataFrame(\n",
+        "                {\n",
+        "                    \"fold\": fold_idx,\n",
+        "                    \"fold_name\": fold_df[\"fold_name\"].iat[0],\n",
+        "                    \"row_id\": test_df[\"row_id\"].values,\n",
+        "                    \"y_true\": y_test.values,\n",
+        "                    \"model\": label,\n",
+        "                    \"y_pred\": y_pred,\n",
+        "                    \"y_proba\": y_proba,\n",
+        "                }\n",
+        "            )\n",
+        "        )\n",
+        "\n",
+        "results_df = pd.DataFrame(results)\n",
+        "predictions_df = pd.concat(prediction_frames, ignore_index=True)\n",
+        "\n",
+        "results_df.head()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Resumo das m\u00e9tricas por modelo\n",
+        "\n",
+        "A tabela a seguir mostra a m\u00e9dia e o desvio padr\u00e3o das m\u00e9tricas em todos os *folds*.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "metrics_summary = (\n",
+        "    results_df\n",
+        "    .groupby([\"model\", \"metric\"])['value']\n",
+        "    .agg(['mean', 'std'])\n",
+        "    .reset_index()\n",
+        ")\n",
+        "metrics_summary\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Gr\u00e1fico comparativo\n",
+        "\n",
+        "O gr\u00e1fico reproduz o exemplo solicitado, com barras pretas representando o benchmark (apenas features cl\u00e1ssicas) e barras amarelas representando o modelo com features cl\u00e1ssicas + qu\u00e2nticas.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "metric_order = [\n",
+        "    \"AUC\",\n",
+        "    \"F1 Score Overall\",\n",
+        "    \"Balanced Accuracy\",\n",
+        "    \"Precision Class 0\",\n",
+        "    \"Precision Class 1\",\n",
+        "    \"Recall Class 0\",\n",
+        "    \"Recall Class 1\",\n",
+        "]\n",
+        "\n",
+        "plot_ready = (\n",
+        "    metrics_summary\n",
+        "    .pivot(index='metric', columns='model', values='mean')\n",
+        "    .reindex(metric_order)\n",
+        ")\n",
+        "\n",
+        "ax = plot_ready.plot(\n",
+        "    kind='bar',\n",
+        "    color={\"Benchmark\": \"#2e2e2e\", \"Quantum\": \"#f1b82d\"},\n",
+        "    edgecolor='black'\n",
+        ")\n",
+        "\n",
+        "ax.set_ylim(0, 1.05)\n",
+        "ax.set_ylabel('Score')\n",
+        "ax.set_xlabel('')\n",
+        "ax.set_title('Toxicity classification with Gradient Boosting')\n",
+        "ax.legend(title='Modelo')\n",
+        "\n",
+        "for container in ax.containers:\n",
+        "    ax.bar_label(container, fmt='%.2f', label_type='edge', padding=3)\n",
+        "\n",
+        "plt.tight_layout()\n",
+        "plt.show()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Predi\u00e7\u00f5es\n",
+        "\n",
+        "As tabelas abaixo exibem, respectivamente, as primeiras linhas das predi\u00e7\u00f5es de teste para o modelo benchmark e para o modelo com features qu\u00e2nticas.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "benchmark_predictions = predictions_df[predictions_df['model'] == 'Benchmark']\n",
+        "quantum_predictions = predictions_df[predictions_df['model'] == 'Quantum']\n",
+        "\n",
+        "benchmark_predictions.head()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "quantum_predictions.head()\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Jupyter notebook that loads the feature folds and trains gradient boosting models
- compare classical features against classical + quantum features with detailed metrics and plots

## Testing
- not run (dependencies unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d6a2b92ea88331817cb47a6ba6e93c