### PR TITLE
Add IQR metric summary for Gradient Boosting notebook

### DIFF
--- a/Gradient_Boosting_Comparison.ipynb
+++ b/Gradient_Boosting_Comparison.ipynb
@@ -4,18 +4,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Compara\u00e7\u00e3o de Gradient Boosting com e sem features qu\u00e2nticas\n",
+    "# Comparação de Gradient Boosting com e sem features quânticas\n",
     "\n",
-    "Este notebook carrega os *folds* dispon\u00edveis na pasta `features/`, treina modelos de Gradient Boosting usando apenas as features cl\u00e1ssicas (`class_0` a `class_12`) e o conjunto combinado de features cl\u00e1ssicas + qu\u00e2nticas (`qf_0` a `qf_12`). Em seguida, comparamos o desempenho entre os dois cen\u00e1rios e geramos as predi\u00e7\u00f5es solicitadas.\n"
+    "Este notebook carrega os *folds* disponíveis na pasta `features/`, treina modelos de Gradient Boosting usando apenas as features clássicas (`class_0` a `class_12`) e o conjunto combinado de features clássicas + quânticas (`qf_0` a `qf_12`). Em seguida, comparamos o desempenho entre os dois cenários e geramos as predições solicitadas.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Depend\u00eancias\n",
+    "## Dependências\n",
     "\n",
-    "O notebook utiliza `pandas`, `numpy`, `scikit-learn`, `matplotlib` e `seaborn`. Caso ainda n\u00e3o as tenha instalado no seu ambiente, execute o comando abaixo em uma c\u00e9lula separada ou diretamente no terminal:\n",
+    "O notebook utiliza `pandas`, `numpy`, `scikit-learn`, `matplotlib` e `seaborn`. Caso ainda não as tenha instalado no seu ambiente, execute o comando abaixo em uma célula separada ou diretamente no terminal:\n",
     "\n",
     "```bash\n",
     "pip install pandas numpy scikit-learn matplotlib seaborn\n",
@@ -43,7 +43,7 @@
     "    roc_auc_score,\n",
     ")\n",
     "\n",
-    "# Configura\u00e7\u00e3o est\u00e9tica padr\u00e3o para os gr\u00e1ficos\n",
+    "# Configuração estética padrão para os gráficos\n",
     "sns.set_style(\"whitegrid\")\n",
     "plt.rcParams.update({\"figure.figsize\": (10, 5), \"axes.titlesize\": 14, \"axes.labelsize\": 12})\n"
    ]
@@ -89,9 +89,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Defini\u00e7\u00e3o dos grupos de features e fun\u00e7\u00e3o de avalia\u00e7\u00e3o\n",
+    "## Definição dos grupos de features e função de avaliação\n",
     "\n",
-    "A fun\u00e7\u00e3o abaixo treina um `GradientBoostingClassifier` para cada conjunto de features em todos os *folds*, calcula as m\u00e9tricas desejadas no conjunto de teste e armazena as predi\u00e7\u00f5es geradas.\n"
+    "A função abaixo treina um `GradientBoostingClassifier` para cada conjunto de features em todos os *folds*, calcula as métricas desejadas no conjunto de teste e armazena as predições geradas.\n"
    ]
   },
   {
@@ -174,9 +174,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Resumo das m\u00e9tricas por modelo\n",
+    "## Resumo das métricas por modelo\n",
     "\n",
-    "A tabela a seguir mostra a mediana e o intervalo interquartil (25%-75%) das m\u00e9tricas em todos os *folds*.\n"
+    "A tabela a seguir mostra a mediana e o intervalo interquartil (25%-75%) das métricas em todos os *folds*.\n"
    ]
   },
   {
@@ -195,6 +195,11 @@
     "    )\n",
     "    .reset_index()\n",
     ")\n",
+    "metrics_summary['iqr'] = metrics_summary['q3'] - metrics_summary['q1']\n",
+    "metrics_summary['median_iqr'] = metrics_summary.apply(\n",
+    "    lambda row: f\"{row['median']:.4f} [{row['q1']:.4f}, {row['q3']:.4f}]\",\n",
+    "    axis=1,\n",
+    ")\n",
     "metrics_summary\n"
    ]
   },
@@ -202,9 +207,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Gr\u00e1fico comparativo\n",
+    "## Gráfico comparativo\n",
     "\n",
-    "O gr\u00e1fico reproduz o exemplo solicitado, com barras pretas representando o benchmark (apenas features cl\u00e1ssicas) e barras amarelas representando o modelo com features cl\u00e1ssicas + qu\u00e2nticas. Os valores exibidos nas barras correspondem \u00e0s medianas por *fold*.\n"
+    "O gráfico reproduz o exemplo solicitado, com barras pretas representando o benchmark (apenas features clássicas) e barras amarelas representando o modelo com features clássicas + quânticas. Os valores exibidos nas barras correspondem às medianas por *fold*.\n"
    ]
   },
   {
@@ -252,9 +257,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Predi\u00e7\u00f5es\n",
+    "## Predições\n",
     "\n",
-    "As tabelas abaixo exibem, respectivamente, as primeiras linhas das predi\u00e7\u00f5es de teste para o modelo benchmark e para o modelo com features qu\u00e2nticas.\n"
+    "As tabelas abaixo exibem, respectivamente, as primeiras linhas das predições de teste para o modelo benchmark e para o modelo com features quânticas.\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- add interquartile range calculations to the Gradient Boosting metrics summary table
- include formatted median and quartile display alongside the existing summary output

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d6cd0b5bf4833193351cd403aedca7