### PR TITLE
Add regressor-driven quantum feature evaluation

### DIFF
--- a/Gradient_Boosting_Comparison.ipynb
+++ b/Gradient_Boosting_Comparison.ipynb
@@ -34,7 +34,7 @@
     "import pandas as pd\n",
     "import seaborn as sns\n",
     "from matplotlib import pyplot as plt\n",
-    "from sklearn.ensemble import GradientBoostingClassifier\n",
+    "from sklearn.ensemble import GradientBoostingClassifier, GradientBoostingRegressor\n",
     "from sklearn.metrics import (\n",
     "    balanced_accuracy_score,\n",
     "    f1_score,\n",
@@ -42,10 +42,12 @@
     "    recall_score,\n",
     "    roc_auc_score,\n",
     ")\n",
+    "from sklearn.multioutput import MultiOutputRegressor\n",
     "\n",
     "# Configuração estética padrão para os gráficos\n",
     "sns.set_style(\"whitegrid\")\n",
-    "plt.rcParams.update({\"figure.figsize\": (10, 5), \"axes.titlesize\": 14, \"axes.labelsize\": 12})\n"
+    "plt.rcParams.update({\"figure.figsize\": (10, 5), \"axes.titlesize\": 14, \"axes.labelsize\": 12})\n",
+    "\n"
    ]
   },
   {
@@ -103,9 +105,28 @@
     "classical_features = [col for col in fold_frames[0].columns if col.startswith(\"class_\")]\n",
     "quantum_features = [col for col in fold_frames[0].columns if col.startswith(\"qf_\")]\n",
     "\n",
+    "# Treinamento do regressor quântico usando todos os dados disponíveis\n",
+    "all_data = pd.concat(fold_frames, ignore_index=True)\n",
+    "\n",
+    "X_reg = all_data[classical_features]\n",
+    "y_reg = all_data[quantum_features]\n",
+    "\n",
+    "quantum_regressor = MultiOutputRegressor(\n",
+    "    GradientBoostingRegressor(random_state=42)\n",
+    ")\n",
+    "quantum_regressor.fit(X_reg, y_reg)\n",
+    "\n",
+    "predicted_quantum_features = [f\"pred_{feature}\" for feature in quantum_features]\n",
+    "\n",
+    "for fold_df in fold_frames:\n",
+    "    predicted_values = quantum_regressor.predict(fold_df[classical_features])\n",
+    "    for pred_column, column_values in zip(predicted_quantum_features, predicted_values.T):\n",
+    "        fold_df[pred_column] = column_values\n",
+    "\n",
     "feature_sets = {\n",
     "    \"Benchmark\": classical_features,\n",
     "    \"Quantum\": classical_features + quantum_features,\n",
+    "    \"Quantum (Regressor)\": classical_features + predicted_quantum_features,\n",
     "}\n",
     "\n",
     "metric_functions = {\n",
@@ -163,6 +184,7 @@
     "                }\n",
     "            )\n",
     "        )\n",
+    "\n",
     "\n",
     "results_df = pd.DataFrame(results)\n",
     "predictions_df = pd.concat(prediction_frames, ignore_index=True)\n",
@@ -234,9 +256,17 @@
     "    .reindex(metric_order)\n",
     ")\n",
     "\n",
+    "plot_ready = plot_ready.reindex(columns=[\"Benchmark\", \"Quantum\", \"Quantum (Regressor)\"])\n",
+    "\n",
+    "model_colors = {\n",
+    "    \"Benchmark\": \"#2e2e2e\",\n",
+    "    \"Quantum\": \"#f1b82d\",\n",
+    "    \"Quantum (Regressor)\": \"#2b8cbe\",\n",
+    "}\n",
+    "\n",
     "ax = plot_ready.plot(\n",
     "    kind='bar',\n",
-    "    color={'Benchmark': '#2e2e2e', 'Quantum': '#f1b82d'},\n",
+    "    color=[model_colors[col] for col in plot_ready.columns],\n",
     "    edgecolor='black'\n",
     ")\n",
     "\n",
@@ -250,7 +280,8 @@
     "    ax.bar_label(container, fmt='%.2f', label_type='edge', padding=3)\n",
     "\n",
     "plt.tight_layout()\n",
-    "plt.show()\n"
+    "plt.show()\n",
+    "\n"
    ]
   },
   {
@@ -270,8 +301,10 @@
    "source": [
     "benchmark_predictions = predictions_df[predictions_df['model'] == 'Benchmark']\n",
     "quantum_predictions = predictions_df[predictions_df['model'] == 'Quantum']\n",
+    "quantum_regressor_predictions = predictions_df[predictions_df['model'] == 'Quantum (Regressor)']\n",
     "\n",
-    "benchmark_predictions.head()\n"
+    "benchmark_predictions.head()\n",
+    "\n"
    ]
   },
   {
@@ -281,6 +314,15 @@
    "outputs": [],
    "source": [
     "quantum_predictions.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "quantum_regressor_predictions.head()\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- import GradientBoostingRegressor and MultiOutputRegressor to support quantum descriptor regression in the notebook
- train a multi-output regressor on all available classical descriptors, append the predicted quantum features to every fold, and evaluate a new "Quantum (Regressor)" feature set alongside the existing models
- expand the comparative bar chart and prediction previews to include the regressor-driven results

## Testing
- jupyter nbconvert --to notebook --execute Gradient_Boosting_Comparison.ipynb --output executed.ipynb --ExecutePreprocessor.timeout=600 *(fails: `jupyter` command not available in the environment)*
- python - <<'PY' ... *(fails: missing dependency `numpy` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d6d722319c8331aba5aa0ab9ea28a8