### PR TITLE
Add deep MLP regression experiment to notebook

### DIFF
--- a/Gradient_Boosting_Comparison.ipynb
+++ b/Gradient_Boosting_Comparison.ipynb
@@ -1,342 +1,410 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Comparação de Gradient Boosting com e sem features quânticas\n",
-    "\n",
-    "Este notebook carrega os *folds* disponíveis na pasta `features/`, treina modelos de Gradient Boosting usando apenas as features clássicas (`class_0` a `class_12`) e o conjunto combinado de features clássicas + quânticas (`qf_0` a `qf_12`). Em seguida, comparamos o desempenho entre os dois cenários e geramos as predições solicitadas.\n"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Comparação de Gradient Boosting com e sem features quânticas\n",
+        "\n",
+        "Este notebook carrega os *folds* disponíveis na pasta `features/`, treina modelos de Gradient Boosting usando apenas as features clássicas (`class_0` a `class_12`) e o conjunto combinado de features clássicas + quânticas (`qf_0` a `qf_12`). Em seguida, comparamos o desempenho entre os dois cenários e geramos as predições solicitadas.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Dependências\n",
+        "\n",
+        "O notebook utiliza `pandas`, `numpy`, `scikit-learn`, `matplotlib` e `seaborn`. Caso ainda não as tenha instalado no seu ambiente, execute o comando abaixo em uma célula separada ou diretamente no terminal:\n",
+        "\n",
+        "```bash\n",
+        "pip install pandas numpy scikit-learn matplotlib seaborn\n",
+        "```\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "import seaborn as sns\n",
+        "from matplotlib import pyplot as plt\n",
+        "from sklearn.ensemble import GradientBoostingClassifier, HistGradientBoostingRegressor\n",
+        "from sklearn.metrics import (\n",
+        "    balanced_accuracy_score,\n",
+        "    f1_score,\n",
+        "    precision_score,\n",
+        "    recall_score,\n",
+        "    roc_auc_score,\n",
+        ")\n",
+        "from sklearn.multioutput import MultiOutputRegressor\n",
+        "\n",
+        "# Configuração estética padrão para os gráficos\n",
+        "sns.set_style(\"whitegrid\")\n",
+        "plt.rcParams.update({\"figure.figsize\": (10, 5), \"axes.titlesize\": 14, \"axes.labelsize\": 12})\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Carregamento dos dados\n",
+        "\n",
+        "Cada CSV em `features/` corresponde a um *fold*. O conjunto possui uma coluna `set` indicando se a amostra pertence ao treino ou ao teste.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "data_dir = Path(\"features\")\n",
+        "fold_paths = sorted(data_dir.glob(\"features_y_fold*.csv\"))\n",
+        "if not fold_paths:\n",
+        "    raise FileNotFoundError(\"Nenhum arquivo `features_y_fold*.csv` foi encontrado na pasta `features/`.\")\n",
+        "\n",
+        "fold_frames = []\n",
+        "for path in fold_paths:\n",
+        "    frame = pd.read_csv(path)\n",
+        "    frame[\"fold_name\"] = path.stem\n",
+        "    fold_frames.append(frame)\n",
+        "\n",
+        "fold_summary = (\n",
+        "    pd.concat(\n",
+        "        [df.assign(set=df[\"set\"].str.lower())[[\"fold\", \"fold_name\", \"set\"]] for df in fold_frames],\n",
+        "        ignore_index=True,\n",
+        "    )\n",
+        "    .value_counts()\n",
+        "    .unstack(fill_value=0)\n",
+        ")\n",
+        "fold_summary\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Definição dos grupos de features e função de avaliação\n",
+        "\n",
+        "A função abaixo treina um `GradientBoostingClassifier` para cada conjunto de features em todos os *folds*, calcula as métricas desejadas no conjunto de teste e armazena as predições geradas.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "classical_features = [col for col in fold_frames[0].columns if col.startswith(\"class_\")]\n",
+        "quantum_features = [col for col in fold_frames[0].columns if col.startswith(\"qf_\")]\n",
+        "\n",
+        "# Treinamento do regressor quântico usando todos os dados disponíveis\n",
+        "all_data = pd.concat(fold_frames, ignore_index=True)\n",
+        "\n",
+        "X_reg = all_data[classical_features]\n",
+        "y_reg = all_data[quantum_features]\n",
+        "\n",
+        "quantum_regressor = MultiOutputRegressor(\n",
+        "    HistGradientBoostingRegressor(random_state=42)\n",
+        ")\n",
+        "quantum_regressor.fit(X_reg, y_reg)\n",
+        "\n",
+        "predicted_quantum_features = [f\"pred_{feature}\" for feature in quantum_features]\n",
+        "\n",
+        "for fold_df in fold_frames:\n",
+        "    predicted_values = quantum_regressor.predict(fold_df[classical_features])\n",
+        "    for pred_column, column_values in zip(predicted_quantum_features, predicted_values.T):\n",
+        "        fold_df[pred_column] = column_values\n",
+        "\n",
+        "feature_sets = {\n",
+        "    \"Benchmark\": classical_features,\n",
+        "    \"Quantum\": classical_features + quantum_features,\n",
+        "    \"Quantum (Regressor)\": classical_features + predicted_quantum_features,\n",
+        "}\n",
+        "\n",
+        "metric_functions = {\n",
+        "    \"AUC\": lambda y_true, y_score, y_pred: roc_auc_score(y_true, y_score) if len(np.unique(y_true)) > 1 else np.nan,\n",
+        "    \"F1 Score Overall\": lambda y_true, y_score, y_pred: f1_score(y_true, y_pred),\n",
+        "    \"Balanced Accuracy\": lambda y_true, y_score, y_pred: balanced_accuracy_score(y_true, y_pred),\n",
+        "    \"Precision Class 0\": lambda y_true, y_score, y_pred: precision_score(y_true, y_pred, pos_label=0),\n",
+        "    \"Precision Class 1\": lambda y_true, y_score, y_pred: precision_score(y_true, y_pred, pos_label=1),\n",
+        "    \"Recall Class 0\": lambda y_true, y_score, y_pred: recall_score(y_true, y_pred, pos_label=0),\n",
+        "    \"Recall Class 1\": lambda y_true, y_score, y_pred: recall_score(y_true, y_pred, pos_label=1),\n",
+        "}\n",
+        "\n",
+        "results = []\n",
+        "prediction_frames = []\n",
+        "\n",
+        "for fold_idx, fold_df in enumerate(fold_frames):\n",
+        "    train_df = fold_df[fold_df[\"set\"] == \"train\"]\n",
+        "    test_df = fold_df[fold_df[\"set\"] == \"test\"]\n",
+        "\n",
+        "    y_train = train_df[\"y\"]\n",
+        "    y_test = test_df[\"y\"]\n",
+        "\n",
+        "    for label, columns in feature_sets.items():\n",
+        "        X_train = train_df[columns]\n",
+        "        X_test = test_df[columns]\n",
+        "\n",
+        "        model = GradientBoostingClassifier(random_state=42)\n",
+        "        model.fit(X_train, y_train)\n",
+        "\n",
+        "        y_proba = model.predict_proba(X_test)[:, 1]\n",
+        "        y_pred = model.predict(X_test)\n",
+        "\n",
+        "        for metric_name, metric_fn in metric_functions.items():\n",
+        "            value = metric_fn(y_test, y_proba, y_pred)\n",
+        "            results.append(\n",
+        "                {\n",
+        "                    \"fold\": fold_idx,\n",
+        "                    \"fold_name\": fold_df[\"fold_name\"].iat[0],\n",
+        "                    \"model\": label,\n",
+        "                    \"metric\": metric_name,\n",
+        "                    \"value\": value,\n",
+        "                }\n",
+        "            )\n",
+        "\n",
+        "        prediction_frames.append(\n",
+        "            pd.DataFrame(\n",
+        "                {\n",
+        "                    \"fold\": fold_idx,\n",
+        "                    \"fold_name\": fold_df[\"fold_name\"].iat[0],\n",
+        "                    \"row_id\": test_df[\"row_id\"].values,\n",
+        "                    \"y_true\": y_test.values,\n",
+        "                    \"model\": label,\n",
+        "                    \"y_pred\": y_pred,\n",
+        "                    \"y_proba\": y_proba,\n",
+        "                }\n",
+        "            )\n",
+        "        )\n",
+        "\n",
+        "\n",
+        "results_df = pd.DataFrame(results)\n",
+        "predictions_df = pd.concat(prediction_frames, ignore_index=True)\n",
+        "\n",
+        "results_df.head()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Resumo das métricas por modelo\n",
+        "\n",
+        "A tabela a seguir mostra a mediana e o intervalo interquartil (25%-75%) das métricas em todos os *folds*.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "metrics_summary = (\n",
+        "    results_df\n",
+        "    .groupby(['model', 'metric'])['value']\n",
+        "    .agg(\n",
+        "        median=lambda s: np.nanmedian(s),\n",
+        "        q1=lambda s: np.nanquantile(s, 0.25),\n",
+        "        q3=lambda s: np.nanquantile(s, 0.75),\n",
+        "    )\n",
+        "    .reset_index()\n",
+        ")\n",
+        "metrics_summary['iqr'] = metrics_summary['q3'] - metrics_summary['q1']\n",
+        "metrics_summary['median_iqr'] = metrics_summary.apply(\n",
+        "    lambda row: f\"{row['median']:.4f} [{row['q1']:.4f}, {row['q3']:.4f}]\",\n",
+        "    axis=1,\n",
+        ")\n",
+        "metrics_summary\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Gráfico comparativo\n",
+        "\n",
+        "O gráfico reproduz o exemplo solicitado, com barras pretas representando o benchmark (apenas features clássicas) e barras amarelas representando o modelo com features clássicas + quânticas. Os valores exibidos nas barras correspondem às medianas por *fold*.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "metric_order = [\n",
+        "    'AUC',\n",
+        "    'F1 Score Overall',\n",
+        "    'Balanced Accuracy',\n",
+        "    'Precision Class 0',\n",
+        "    'Precision Class 1',\n",
+        "    'Recall Class 0',\n",
+        "    'Recall Class 1',\n",
+        "]\n",
+        "\n",
+        "plot_ready = (\n",
+        "    metrics_summary\n",
+        "    .pivot(index='metric', columns='model', values='median')\n",
+        "    .reindex(metric_order)\n",
+        ")\n",
+        "\n",
+        "plot_ready = plot_ready.reindex(columns=[\"Benchmark\", \"Quantum\", \"Quantum (Regressor)\"])\n",
+        "\n",
+        "model_colors = {\n",
+        "    \"Benchmark\": \"#2e2e2e\",\n",
+        "    \"Quantum\": \"#f1b82d\",\n",
+        "    \"Quantum (Regressor)\": \"#2b8cbe\",\n",
+        "}\n",
+        "\n",
+        "ax = plot_ready.plot(\n",
+        "    kind='bar',\n",
+        "    color=[model_colors[col] for col in plot_ready.columns],\n",
+        "    edgecolor='black'\n",
+        ")\n",
+        "\n",
+        "ax.set_ylim(0, 1.05)\n",
+        "ax.set_ylabel('Score')\n",
+        "ax.set_xlabel('')\n",
+        "ax.set_title('Toxicity classification with Gradient Boosting')\n",
+        "ax.legend(title='Modelo')\n",
+        "\n",
+        "for container in ax.containers:\n",
+        "    ax.bar_label(container, fmt='%.2f', label_type='edge', padding=3)\n",
+        "\n",
+        "plt.tight_layout()\n",
+        "plt.show()\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Predições\n",
+        "\n",
+        "As tabelas abaixo exibem, respectivamente, as primeiras linhas das predições de teste para o modelo benchmark e para o modelo com features quânticas.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "benchmark_predictions = predictions_df[predictions_df['model'] == 'Benchmark']\n",
+        "quantum_predictions = predictions_df[predictions_df['model'] == 'Quantum']\n",
+        "quantum_regressor_predictions = predictions_df[predictions_df['model'] == 'Quantum (Regressor)']\n",
+        "\n",
+        "benchmark_predictions.head()\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "quantum_predictions.head()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "quantum_regressor_predictions.head()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Regressor profundo para aproximar as features quânticas\n\nA seção a seguir replica o experimento com um MLP profundo implementado em NumPy. O objetivo é prever as features quânticas a partir das features clássicas e, em seguida, avaliar o impacto dessas predições no modelo de classificação."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import math\nfrom typing import List, Optional, Sequence\n\nimport numpy as np\n\nclass DeepNumpyMLPRegressor:\n    \"\"\"Implementação simples de um MLP com ReLU e optimização Adam.\"\"\"\n\n    def __init__(\n        self,\n        hidden_layers: Sequence[int] = (256, 128, 64),\n        learning_rate: float = 1e-3,\n        epochs: int = 100,\n        batch_size: int = 256,\n        random_state: Optional[int] = 42,\n        beta1: float = 0.9,\n        beta2: float = 0.999,\n        eps: float = 1e-8,\n    ) -> None:\n        self.hidden_layers = tuple(hidden_layers)\n        self.learning_rate = learning_rate\n        self.epochs = epochs\n        self.batch_size = batch_size\n        self.random_state = random_state\n        self.beta1 = beta1\n        self.beta2 = beta2\n        self.eps = eps\n        self.weights: List[np.ndarray] = []\n        self.biases: List[np.ndarray] = []\n        self.m_w: List[np.ndarray] = []\n        self.v_w: List[np.ndarray] = []\n        self.m_b: List[np.ndarray] = []\n        self.v_b: List[np.ndarray] = []\n        self._step = 0\n\n    def _initialise(self, n_features: int, n_outputs: int) -> None:\n        layer_sizes = [n_features, *self.hidden_layers, n_outputs]\n        rng = np.random.default_rng(self.random_state)\n        self.weights.clear()\n        self.biases.clear()\n        self.m_w.clear()\n        self.v_w.clear()\n        self.m_b.clear()\n        self.v_b.clear()\n        for in_dim, out_dim in zip(layer_sizes[:-1], layer_sizes[1:]):\n            limit = math.sqrt(6.0 / (in_dim + out_dim))\n            weight = rng.uniform(-limit, limit, size=(in_dim, out_dim)).astype(np.float64)\n            bias = np.zeros(out_dim, dtype=np.float64)\n            self.weights.append(weight)\n            self.biases.append(bias)\n            self.m_w.append(np.zeros_like(weight))\n            self.v_w.append(np.zeros_like(weight))\n            self.m_b.append(np.zeros_like(bias))\n            self.v_b.append(np.zeros_like(bias))\n        self._step = 0\n\n    @staticmethod\n    def _relu(values: np.ndarray) -> np.ndarray:\n        return np.maximum(0.0, values)\n\n    @staticmethod\n    def _relu_grad(values: np.ndarray) -> np.ndarray:\n        grad = np.zeros_like(values)\n        grad[values > 0.0] = 1.0\n        return grad\n\n    def _forward(self, batch: np.ndarray):\n        activations = [batch]\n        pre_activations: List[np.ndarray] = []\n        current = batch\n        for idx, (weight, bias) in enumerate(zip(self.weights, self.biases)):\n            linear = current @ weight + bias\n            pre_activations.append(linear)\n            if idx == len(self.weights) - 1:\n                current = linear\n            else:\n                current = self._relu(linear)\n            activations.append(current)\n        return pre_activations, activations\n\n    def _adam_step(self, grads_w: List[np.ndarray], grads_b: List[np.ndarray]) -> None:\n        self._step += 1\n        lr = self.learning_rate\n        for idx, (grad_w, grad_b) in enumerate(zip(grads_w, grads_b)):\n            self.m_w[idx] = self.beta1 * self.m_w[idx] + (1 - self.beta1) * grad_w\n            self.v_w[idx] = self.beta2 * self.v_w[idx] + (1 - self.beta2) * (grad_w ** 2)\n            self.m_b[idx] = self.beta1 * self.m_b[idx] + (1 - self.beta1) * grad_b\n            self.v_b[idx] = self.beta2 * self.v_b[idx] + (1 - self.beta2) * (grad_b ** 2)\n            m_hat_w = self.m_w[idx] / (1 - self.beta1 ** self._step)\n            v_hat_w = self.v_w[idx] / (1 - self.beta2 ** self._step)\n            m_hat_b = self.m_b[idx] / (1 - self.beta1 ** self._step)\n            v_hat_b = self.v_b[idx] / (1 - self.beta2 ** self._step)\n            self.weights[idx] -= lr * m_hat_w / (np.sqrt(v_hat_w) + self.eps)\n            self.biases[idx] -= lr * m_hat_b / (np.sqrt(v_hat_b) + self.eps)\n\n    def fit(self, features: np.ndarray, targets: np.ndarray) -> None:\n        features = np.asarray(features, dtype=np.float64)\n        targets = np.asarray(targets, dtype=np.float64)\n        if features.ndim != 2:\n            raise ValueError('As features devem ser uma matriz 2D.')\n        if targets.ndim != 2:\n            raise ValueError('Os alvos devem ser uma matriz 2D.')\n        self._initialise(features.shape[1], targets.shape[1])\n        rng = np.random.default_rng(self.random_state)\n        n_samples = features.shape[0]\n        indices = np.arange(n_samples)\n        for epoch in range(1, self.epochs + 1):\n            rng.shuffle(indices)\n            for start in range(0, n_samples, self.batch_size):\n                end = min(start + self.batch_size, n_samples)\n                batch_idx = indices[start:end]\n                batch_features = features[batch_idx]\n                batch_targets = targets[batch_idx]\n                pre_acts, activations = self._forward(batch_features)\n                delta = (activations[-1] - batch_targets) / batch_features.shape[0]\n                grads_w: List[np.ndarray] = []\n                grads_b: List[np.ndarray] = []\n                for layer_idx in reversed(range(len(self.weights))):\n                    grad_w = activations[layer_idx].T @ delta\n                    grad_b = delta.sum(axis=0)\n                    grads_w.insert(0, grad_w)\n                    grads_b.insert(0, grad_b)\n                    if layer_idx != 0:\n                        delta = (delta @ self.weights[layer_idx].T) * self._relu_grad(pre_acts[layer_idx - 1])\n                self._adam_step(grads_w, grads_b)\n            if epoch % 10 == 0 or epoch == self.epochs:\n                _, activations = self._forward(features)\n                mse = np.mean((activations[-1] - targets) ** 2)\n                print(f'Epoch {epoch:03d} - MSE: {mse:.6f}')\n\n    def predict(self, features: np.ndarray) -> np.ndarray:\n        features = np.asarray(features, dtype=np.float64)\n        _, activations = self._forward(features)\n        return activations[-1]"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "deep_regressor = DeepNumpyMLPRegressor(\n    hidden_layers=(512, 256, 128, 64),\n    learning_rate=5e-4,\n    epochs=80,\n    batch_size=256,\n    random_state=42,\n)\ndeep_regressor.fit(X_reg.values, y_reg.values)\n\ndl_predicted_quantum_features = [f'dl_pred_{feature}' for feature in quantum_features]\nfor fold_df in fold_frames:\n    predictions = deep_regressor.predict(fold_df[classical_features].values)\n    for column, values in zip(dl_predicted_quantum_features, predictions.T):\n        fold_df[column] = values"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "dl_feature_set = classical_features + dl_predicted_quantum_features\ndl_results = []\ndl_prediction_frames = []\nfor fold_idx, fold_df in enumerate(fold_frames):\n    train_df = fold_df[fold_df['set'] == 'train']\n    test_df = fold_df[fold_df['set'] == 'test']\n    y_train = train_df['y']\n    y_test = test_df['y']\n    X_train = train_df[dl_feature_set]\n    X_test = test_df[dl_feature_set]\n    model = GradientBoostingClassifier(random_state=42)\n    model.fit(X_train, y_train)\n    y_proba = model.predict_proba(X_test)[:, 1]\n    y_pred = model.predict(X_test)\n    for metric_name, metric_fn in metric_functions.items():\n        value = metric_fn(y_test, y_proba, y_pred)\n        dl_results.append({\n            'fold': fold_idx,\n            'fold_name': fold_df['fold_name'].iat[0],\n            'model': 'Quantum (Deep MLP)',\n            'metric': metric_name,\n            'value': value,\n        })\n    dl_prediction_frames.append(pd.DataFrame({\n        'fold': fold_idx,\n        'fold_name': fold_df['fold_name'].iat[0],\n        'row_id': test_df['row_id'].values,\n        'y_true': y_test.values,\n        'model': 'Quantum (Deep MLP)',\n        'y_pred': y_pred,\n        'y_proba': y_proba,\n    }))\n\nresults_df = pd.concat([results_df, pd.DataFrame(dl_results)], ignore_index=True)\npredictions_df = pd.concat([predictions_df, pd.concat(dl_prediction_frames, ignore_index=True)], ignore_index=True)\nresults_df[results_df['model'] == 'Quantum (Deep MLP)'].head()"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Métricas atualizadas\n\nAs tabelas e gráficos são recalculados para incluir o modelo com as features estimadas pelo MLP profundo."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "metrics_summary = (\n    results_df\n    .groupby(['model', 'metric'])['value']\n    .agg(\n        median=lambda s: np.nanmedian(s),\n        q1=lambda s: np.nanquantile(s, 0.25),\n        q3=lambda s: np.nanquantile(s, 0.75),\n    )\n    .reset_index()\n)\nmetrics_summary['iqr'] = metrics_summary['q3'] - metrics_summary['q1']\nmetrics_summary['median_iqr'] = metrics_summary.apply(\n    lambda row: f\"{row['median']:.3f} (IQR: {row['q1']:.3f}-{row['q3']:.3f})\"\n    axis=1\n)\nmetrics_summary"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "metric_order = [\n    'AUC',\n    'F1 Score Overall',\n    'Balanced Accuracy',\n    'Precision Class 0',\n    'Precision Class 1',\n    'Recall Class 0',\n    'Recall Class 1',\n]\nplot_ready = (\n    metrics_summary\n    .pivot(index='metric', columns='model', values='median')\n    .reindex(metric_order)\n)\nplot_ready = plot_ready.reindex(columns=[\n    'Benchmark',\n    'Quantum',\n    'Quantum (Regressor)',\n    'Quantum (Deep MLP)',\n])\nmodel_colors = {\n    'Benchmark': '#2c2c2c',\n    'Quantum': '#f1c40f',\n    'Quantum (Regressor)': '#3498db',\n    'Quantum (Deep MLP)': '#9b59b6',\n}\nax = plot_ready.plot(kind='bar', color=[model_colors[col] for col in plot_ready.columns], figsize=(12, 6))\nax.set_ylabel('Mediana por fold')\nax.set_xlabel('Métrica')\nax.set_title('Comparação de desempenho com predições de features quânticas')\nax.set_xticklabels(ax.get_xticklabels(), rotation=45, ha='right')\nax.legend(loc='lower right')\nplt.tight_layout()\nplt.show()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "dl_predictions = predictions_df[predictions_df['model'] == 'Quantum (Deep MLP)']\ndl_predictions.head()"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Dependências\n",
-    "\n",
-    "O notebook utiliza `pandas`, `numpy`, `scikit-learn`, `matplotlib` e `seaborn`. Caso ainda não as tenha instalado no seu ambiente, execute o comando abaixo em uma célula separada ou diretamente no terminal:\n",
-    "\n",
-    "```bash\n",
-    "pip install pandas numpy scikit-learn matplotlib seaborn\n",
-    "```\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "from pathlib import Path\n",
-    "\n",
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "import seaborn as sns\n",
-    "from matplotlib import pyplot as plt\n",
-    "from sklearn.ensemble import GradientBoostingClassifier, HistGradientBoostingRegressor\n",
-    "from sklearn.metrics import (\n",
-    "    balanced_accuracy_score,\n",
-    "    f1_score,\n",
-    "    precision_score,\n",
-    "    recall_score,\n",
-    "    roc_auc_score,\n",
-    ")\n",
-    "from sklearn.multioutput import MultiOutputRegressor\n",
-    "\n",
-    "# Configuração estética padrão para os gráficos\n",
-    "sns.set_style(\"whitegrid\")\n",
-    "plt.rcParams.update({\"figure.figsize\": (10, 5), \"axes.titlesize\": 14, \"axes.labelsize\": 12})\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Carregamento dos dados\n",
-    "\n",
-    "Cada CSV em `features/` corresponde a um *fold*. O conjunto possui uma coluna `set` indicando se a amostra pertence ao treino ou ao teste.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "data_dir = Path(\"features\")\n",
-    "fold_paths = sorted(data_dir.glob(\"features_y_fold*.csv\"))\n",
-    "if not fold_paths:\n",
-    "    raise FileNotFoundError(\"Nenhum arquivo `features_y_fold*.csv` foi encontrado na pasta `features/`.\")\n",
-    "\n",
-    "fold_frames = []\n",
-    "for path in fold_paths:\n",
-    "    frame = pd.read_csv(path)\n",
-    "    frame[\"fold_name\"] = path.stem\n",
-    "    fold_frames.append(frame)\n",
-    "\n",
-    "fold_summary = (\n",
-    "    pd.concat(\n",
-    "        [df.assign(set=df[\"set\"].str.lower())[[\"fold\", \"fold_name\", \"set\"]] for df in fold_frames],\n",
-    "        ignore_index=True,\n",
-    "    )\n",
-    "    .value_counts()\n",
-    "    .unstack(fill_value=0)\n",
-    ")\n",
-    "fold_summary\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Definição dos grupos de features e função de avaliação\n",
-    "\n",
-    "A função abaixo treina um `GradientBoostingClassifier` para cada conjunto de features em todos os *folds*, calcula as métricas desejadas no conjunto de teste e armazena as predições geradas.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "classical_features = [col for col in fold_frames[0].columns if col.startswith(\"class_\")]\n",
-    "quantum_features = [col for col in fold_frames[0].columns if col.startswith(\"qf_\")]\n",
-    "\n",
-    "# Treinamento do regressor quântico usando todos os dados disponíveis\n",
-    "all_data = pd.concat(fold_frames, ignore_index=True)\n",
-    "\n",
-    "X_reg = all_data[classical_features]\n",
-    "y_reg = all_data[quantum_features]\n",
-    "\n",
-    "quantum_regressor = MultiOutputRegressor(\n",
-    "    HistGradientBoostingRegressor(random_state=42)\n",
-    ")\n",
-    "quantum_regressor.fit(X_reg, y_reg)\n",
-    "\n",
-    "predicted_quantum_features = [f\"pred_{feature}\" for feature in quantum_features]\n",
-    "\n",
-    "for fold_df in fold_frames:\n",
-    "    predicted_values = quantum_regressor.predict(fold_df[classical_features])\n",
-    "    for pred_column, column_values in zip(predicted_quantum_features, predicted_values.T):\n",
-    "        fold_df[pred_column] = column_values\n",
-    "\n",
-    "feature_sets = {\n",
-    "    \"Benchmark\": classical_features,\n",
-    "    \"Quantum\": classical_features + quantum_features,\n",
-    "    \"Quantum (Regressor)\": classical_features + predicted_quantum_features,\n",
-    "}\n",
-    "\n",
-    "metric_functions = {\n",
-    "    \"AUC\": lambda y_true, y_score, y_pred: roc_auc_score(y_true, y_score) if len(np.unique(y_true)) > 1 else np.nan,\n",
-    "    \"F1 Score Overall\": lambda y_true, y_score, y_pred: f1_score(y_true, y_pred),\n",
-    "    \"Balanced Accuracy\": lambda y_true, y_score, y_pred: balanced_accuracy_score(y_true, y_pred),\n",
-    "    \"Precision Class 0\": lambda y_true, y_score, y_pred: precision_score(y_true, y_pred, pos_label=0),\n",
-    "    \"Precision Class 1\": lambda y_true, y_score, y_pred: precision_score(y_true, y_pred, pos_label=1),\n",
-    "    \"Recall Class 0\": lambda y_true, y_score, y_pred: recall_score(y_true, y_pred, pos_label=0),\n",
-    "    \"Recall Class 1\": lambda y_true, y_score, y_pred: recall_score(y_true, y_pred, pos_label=1),\n",
-    "}\n",
-    "\n",
-    "results = []\n",
-    "prediction_frames = []\n",
-    "\n",
-    "for fold_idx, fold_df in enumerate(fold_frames):\n",
-    "    train_df = fold_df[fold_df[\"set\"] == \"train\"]\n",
-    "    test_df = fold_df[fold_df[\"set\"] == \"test\"]\n",
-    "\n",
-    "    y_train = train_df[\"y\"]\n",
-    "    y_test = test_df[\"y\"]\n",
-    "\n",
-    "    for label, columns in feature_sets.items():\n",
-    "        X_train = train_df[columns]\n",
-    "        X_test = test_df[columns]\n",
-    "\n",
-    "        model = GradientBoostingClassifier(random_state=42)\n",
-    "        model.fit(X_train, y_train)\n",
-    "\n",
-    "        y_proba = model.predict_proba(X_test)[:, 1]\n",
-    "        y_pred = model.predict(X_test)\n",
-    "\n",
-    "        for metric_name, metric_fn in metric_functions.items():\n",
-    "            value = metric_fn(y_test, y_proba, y_pred)\n",
-    "            results.append(\n",
-    "                {\n",
-    "                    \"fold\": fold_idx,\n",
-    "                    \"fold_name\": fold_df[\"fold_name\"].iat[0],\n",
-    "                    \"model\": label,\n",
-    "                    \"metric\": metric_name,\n",
-    "                    \"value\": value,\n",
-    "                }\n",
-    "            )\n",
-    "\n",
-    "        prediction_frames.append(\n",
-    "            pd.DataFrame(\n",
-    "                {\n",
-    "                    \"fold\": fold_idx,\n",
-    "                    \"fold_name\": fold_df[\"fold_name\"].iat[0],\n",
-    "                    \"row_id\": test_df[\"row_id\"].values,\n",
-    "                    \"y_true\": y_test.values,\n",
-    "                    \"model\": label,\n",
-    "                    \"y_pred\": y_pred,\n",
-    "                    \"y_proba\": y_proba,\n",
-    "                }\n",
-    "            )\n",
-    "        )\n",
-    "\n",
-    "\n",
-    "results_df = pd.DataFrame(results)\n",
-    "predictions_df = pd.concat(prediction_frames, ignore_index=True)\n",
-    "\n",
-    "results_df.head()\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Resumo das métricas por modelo\n",
-    "\n",
-    "A tabela a seguir mostra a mediana e o intervalo interquartil (25%-75%) das métricas em todos os *folds*.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "metrics_summary = (\n",
-    "    results_df\n",
-    "    .groupby(['model', 'metric'])['value']\n",
-    "    .agg(\n",
-    "        median=lambda s: np.nanmedian(s),\n",
-    "        q1=lambda s: np.nanquantile(s, 0.25),\n",
-    "        q3=lambda s: np.nanquantile(s, 0.75),\n",
-    "    )\n",
-    "    .reset_index()\n",
-    ")\n",
-    "metrics_summary['iqr'] = metrics_summary['q3'] - metrics_summary['q1']\n",
-    "metrics_summary['median_iqr'] = metrics_summary.apply(\n",
-    "    lambda row: f\"{row['median']:.4f} [{row['q1']:.4f}, {row['q3']:.4f}]\",\n",
-    "    axis=1,\n",
-    ")\n",
-    "metrics_summary\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Gráfico comparativo\n",
-    "\n",
-    "O gráfico reproduz o exemplo solicitado, com barras pretas representando o benchmark (apenas features clássicas) e barras amarelas representando o modelo com features clássicas + quânticas. Os valores exibidos nas barras correspondem às medianas por *fold*.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "metric_order = [\n",
-    "    'AUC',\n",
-    "    'F1 Score Overall',\n",
-    "    'Balanced Accuracy',\n",
-    "    'Precision Class 0',\n",
-    "    'Precision Class 1',\n",
-    "    'Recall Class 0',\n",
-    "    'Recall Class 1',\n",
-    "]\n",
-    "\n",
-    "plot_ready = (\n",
-    "    metrics_summary\n",
-    "    .pivot(index='metric', columns='model', values='median')\n",
-    "    .reindex(metric_order)\n",
-    ")\n",
-    "\n",
-    "plot_ready = plot_ready.reindex(columns=[\"Benchmark\", \"Quantum\", \"Quantum (Regressor)\"])\n",
-    "\n",
-    "model_colors = {\n",
-    "    \"Benchmark\": \"#2e2e2e\",\n",
-    "    \"Quantum\": \"#f1b82d\",\n",
-    "    \"Quantum (Regressor)\": \"#2b8cbe\",\n",
-    "}\n",
-    "\n",
-    "ax = plot_ready.plot(\n",
-    "    kind='bar',\n",
-    "    color=[model_colors[col] for col in plot_ready.columns],\n",
-    "    edgecolor='black'\n",
-    ")\n",
-    "\n",
-    "ax.set_ylim(0, 1.05)\n",
-    "ax.set_ylabel('Score')\n",
-    "ax.set_xlabel('')\n",
-    "ax.set_title('Toxicity classification with Gradient Boosting')\n",
-    "ax.legend(title='Modelo')\n",
-    "\n",
-    "for container in ax.containers:\n",
-    "    ax.bar_label(container, fmt='%.2f', label_type='edge', padding=3)\n",
-    "\n",
-    "plt.tight_layout()\n",
-    "plt.show()\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Predições\n",
-    "\n",
-    "As tabelas abaixo exibem, respectivamente, as primeiras linhas das predições de teste para o modelo benchmark e para o modelo com features quânticas.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "benchmark_predictions = predictions_df[predictions_df['model'] == 'Benchmark']\n",
-    "quantum_predictions = predictions_df[predictions_df['model'] == 'Quantum']\n",
-    "quantum_regressor_predictions = predictions_df[predictions_df['model'] == 'Quantum (Regressor)']\n",
-    "\n",
-    "benchmark_predictions.head()\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "quantum_predictions.head()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "quantum_regressor_predictions.head()\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "pygments_lexer": "ipython3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/deep_learning_regressor.py
+++ b/deep_learning_regressor.py
@@ -1,0 +1,477 @@
+"""Treina um regressor profundo (MLP) para aproximar características quânticas."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
+
+
+@dataclass
+class Dataset:
+    """Container for the regression matrices."""
+
+    features: List[List[float]]
+    targets: List[List[float]]
+    feature_names: Sequence[str]
+    target_names: Sequence[str]
+
+
+class DeepMLPRegressor:
+    """Minimal multi-layer perceptron regressor implemented without NumPy."""
+
+    def __init__(
+        self,
+        hidden_layers: Sequence[int],
+        learning_rate: float,
+        epochs: int,
+        batch_size: int,
+        random_state: int,
+        beta1: float = 0.9,
+        beta2: float = 0.999,
+        eps: float = 1e-8,
+    ) -> None:
+        self.hidden_layers = tuple(hidden_layers)
+        self.learning_rate = learning_rate
+        self.epochs = epochs
+        self.batch_size = batch_size
+        self.random_state = random_state
+        self.beta1 = beta1
+        self.beta2 = beta2
+        self.eps = eps
+
+        self._weights: List[List[List[float]]] = []
+        self._biases: List[List[float]] = []
+        self._m_w: List[List[List[float]]] = []
+        self._v_w: List[List[List[float]]] = []
+        self._m_b: List[List[float]] = []
+        self._v_b: List[List[float]] = []
+        self._step = 0
+
+    @staticmethod
+    def _zeros_matrix(rows: int, cols: int) -> List[List[float]]:
+        return [[0.0 for _ in range(cols)] for _ in range(rows)]
+
+    @staticmethod
+    def _zeros_vector(size: int) -> List[float]:
+        return [0.0 for _ in range(size)]
+
+    def _initialize(self, n_features: int, n_outputs: int) -> None:
+        layer_sizes = [n_features, *self.hidden_layers, n_outputs]
+        rng = random.Random(self.random_state)
+
+        self._weights = []
+        self._biases = []
+        self._m_w = []
+        self._v_w = []
+        self._m_b = []
+        self._v_b = []
+
+        for in_dim, out_dim in zip(layer_sizes[:-1], layer_sizes[1:]):
+            limit = math.sqrt(6.0 / (in_dim + out_dim))
+            weight_matrix = []
+            for _ in range(in_dim):
+                weight_matrix.append([rng.uniform(-limit, limit) for _ in range(out_dim)])
+            bias_vector = [0.0 for _ in range(out_dim)]
+
+            self._weights.append(weight_matrix)
+            self._biases.append(bias_vector)
+            self._m_w.append(self._zeros_matrix(in_dim, out_dim))
+            self._v_w.append(self._zeros_matrix(in_dim, out_dim))
+            self._m_b.append(self._zeros_vector(out_dim))
+            self._v_b.append(self._zeros_vector(out_dim))
+
+        self._step = 0
+
+    @staticmethod
+    def _relu(values: List[float]) -> List[float]:
+        return [value if value > 0.0 else 0.0 for value in values]
+
+    @staticmethod
+    def _relu_grad(values: List[float]) -> List[float]:
+        return [1.0 if value > 0.0 else 0.0 for value in values]
+
+    @staticmethod
+    def _matvec(weights: List[List[float]], vector: List[float]) -> List[float]:
+        output_dim = len(weights[0])
+        result = [0.0 for _ in range(output_dim)]
+        for input_idx, weight_row in enumerate(weights):
+            contribution = vector[input_idx]
+            for output_idx in range(output_dim):
+                result[output_idx] += weight_row[output_idx] * contribution
+        return result
+
+    @staticmethod
+    def _add_vectors(vec1: List[float], vec2: List[float]) -> List[float]:
+        return [a + b for a, b in zip(vec1, vec2)]
+
+    def _forward_single(self, vector: List[float]) -> Tuple[List[List[float]], List[List[float]]]:
+        activations = [vector]
+        pre_activations: List[List[float]] = []
+        current = vector
+
+        for layer_idx, (weight, bias) in enumerate(zip(self._weights, self._biases)):
+            linear = self._add_vectors(self._matvec(weight, current), bias)
+            pre_activations.append(linear)
+            if layer_idx == len(self._weights) - 1:
+                current = linear
+            else:
+                current = self._relu(linear)
+            activations.append(current)
+
+        return pre_activations, activations
+
+    def _backpropagate(
+        self,
+        expected: List[float],
+        pre_acts: List[List[float]],
+        acts: List[List[float]],
+        grads_w: List[List[List[float]]],
+        grads_b: List[List[float]],
+    ) -> None:
+        delta = [acts[-1][i] - expected[i] for i in range(len(expected))]
+
+        for layer_idx in reversed(range(len(self._weights))):
+            # Accumulate gradients for the current layer
+            for input_idx, activation in enumerate(acts[layer_idx]):
+                for output_idx, delta_value in enumerate(delta):
+                    grads_w[layer_idx][input_idx][output_idx] += activation * delta_value
+            for output_idx, delta_value in enumerate(delta):
+                grads_b[layer_idx][output_idx] += delta_value
+
+            if layer_idx != 0:
+                next_delta = [0.0 for _ in range(len(self._weights[layer_idx - 1][0]))]
+                relu_grad = self._relu_grad(pre_acts[layer_idx - 1])
+                for input_idx in range(len(next_delta)):
+                    error = 0.0
+                    for output_idx, delta_value in enumerate(delta):
+                        error += self._weights[layer_idx][input_idx][output_idx] * delta_value
+                    next_delta[input_idx] = error * relu_grad[input_idx]
+                delta = next_delta
+            else:
+                delta = []
+
+    def _apply_adam(self, grads_w: List[List[List[float]]], grads_b: List[List[float]]) -> None:
+        self._step += 1
+        lr = self.learning_rate
+
+        for layer_idx in range(len(self._weights)):
+            for input_idx in range(len(self._weights[layer_idx])):
+                for output_idx in range(len(self._weights[layer_idx][input_idx])):
+                    grad = grads_w[layer_idx][input_idx][output_idx]
+                    self._m_w[layer_idx][input_idx][output_idx] = (
+                        self.beta1 * self._m_w[layer_idx][input_idx][output_idx]
+                        + (1 - self.beta1) * grad
+                    )
+                    self._v_w[layer_idx][input_idx][output_idx] = (
+                        self.beta2 * self._v_w[layer_idx][input_idx][output_idx]
+                        + (1 - self.beta2) * grad * grad
+                    )
+                    m_hat = self._m_w[layer_idx][input_idx][output_idx] / (
+                        1 - self.beta1 ** self._step
+                    )
+                    v_hat = self._v_w[layer_idx][input_idx][output_idx] / (
+                        1 - self.beta2 ** self._step
+                    )
+                    self._weights[layer_idx][input_idx][output_idx] -= (
+                        lr * m_hat / (math.sqrt(v_hat) + self.eps)
+                    )
+
+            for output_idx in range(len(self._biases[layer_idx])):
+                grad_b = grads_b[layer_idx][output_idx]
+                self._m_b[layer_idx][output_idx] = (
+                    self.beta1 * self._m_b[layer_idx][output_idx] + (1 - self.beta1) * grad_b
+                )
+                self._v_b[layer_idx][output_idx] = (
+                    self.beta2 * self._v_b[layer_idx][output_idx] + (1 - self.beta2) * grad_b * grad_b
+                )
+                m_hat_b = self._m_b[layer_idx][output_idx] / (1 - self.beta1 ** self._step)
+                v_hat_b = self._v_b[layer_idx][output_idx] / (1 - self.beta2 ** self._step)
+                self._biases[layer_idx][output_idx] -= lr * m_hat_b / (math.sqrt(v_hat_b) + self.eps)
+
+    def fit(self, X: List[List[float]], y: List[List[float]]) -> None:
+        if not X or not y:
+            raise ValueError("Os dados de treinamento não podem estar vazios.")
+        if len(X) != len(y):
+            raise ValueError("O número de amostras e de alvos deve ser igual.")
+
+        self._initialize(len(X[0]), len(y[0]))
+        rng = random.Random(self.random_state)
+
+        for _ in range(self.epochs):
+            indices = list(range(len(X)))
+            rng.shuffle(indices)
+
+            for start in range(0, len(indices), self.batch_size):
+                batch_indices = indices[start : start + self.batch_size]
+                self._current_batch_size = len(batch_indices)
+
+                grads_w = [self._zeros_matrix(len(layer), len(layer[0])) for layer in self._weights]
+                grads_b = [self._zeros_vector(len(bias)) for bias in self._biases]
+
+                for idx in batch_indices:
+                    pre_acts, acts = self._forward_single(X[idx])
+                    self._backpropagate(y[idx], pre_acts, acts, grads_w, grads_b)
+
+                batch_scale = 1.0 / max(1, len(batch_indices))
+                for layer_idx in range(len(grads_w)):
+                    for input_idx in range(len(grads_w[layer_idx])):
+                        for output_idx in range(len(grads_w[layer_idx][input_idx])):
+                            grads_w[layer_idx][input_idx][output_idx] *= batch_scale
+                    for output_idx in range(len(grads_b[layer_idx])):
+                        grads_b[layer_idx][output_idx] *= batch_scale
+
+                self._apply_adam(grads_w, grads_b)
+
+    def predict(self, X: List[List[float]]) -> List[List[float]]:
+        if not self._weights:
+            raise RuntimeError("O modelo ainda não foi treinado.")
+
+        predictions: List[List[float]] = []
+        for vector in X:
+            _, activations = self._forward_single(vector)
+            predictions.append(list(activations[-1]))
+        return predictions
+
+
+def read_feature_folds(data_dir: Path) -> Dataset:
+    """Load all feature folds available in ``data_dir`` without NumPy or pandas."""
+
+    fold_paths = sorted(data_dir.glob("features_y_fold*.csv"))
+    if not fold_paths:
+        raise FileNotFoundError(
+            "Nenhum arquivo `features_y_fold*.csv` foi encontrado na pasta especificada."
+        )
+
+    feature_names: List[str] | None = None
+    target_names: List[str] | None = None
+    features: List[List[float]] = []
+    targets: List[List[float]] = []
+
+    for path in fold_paths:
+        with path.open(newline="") as handle:
+            reader = csv.DictReader(handle)
+            if feature_names is None or target_names is None:
+                columns = reader.fieldnames or []
+                feature_names = [col for col in columns if col.startswith("class_")]
+                target_names = [col for col in columns if col.startswith("qf_")]
+                if not feature_names or not target_names:
+                    raise ValueError(
+                        "Não foi possível localizar as colunas de atributos clássicos ou alvos quânticos."
+                    )
+
+            for row in reader:
+                features.append([float(row[name]) for name in feature_names])
+                targets.append([float(row[name]) for name in target_names])
+
+    return Dataset(
+        features=features,
+        targets=targets,
+        feature_names=feature_names or [],
+        target_names=target_names or [],
+    )
+
+
+def train_test_split(
+    X: List[List[float]],
+    y: List[List[float]],
+    test_size: float,
+    random_state: int,
+) -> Tuple[List[List[float]], List[List[float]], List[List[float]], List[List[float]]]:
+    if not 0.0 < test_size < 1.0:
+        raise ValueError("test_size deve estar entre 0 e 1.")
+
+    rng = random.Random(random_state)
+    indices = list(range(len(X)))
+    rng.shuffle(indices)
+
+    test_count = max(1, int(round(len(indices) * test_size)))
+    test_indices = indices[:test_count]
+    train_indices = indices[test_count:]
+
+    if not train_indices:
+        raise ValueError("Não há dados suficientes para o conjunto de treinamento.")
+
+    X_train = [X[idx] for idx in train_indices]
+    X_test = [X[idx] for idx in test_indices]
+    y_train = [y[idx] for idx in train_indices]
+    y_test = [y[idx] for idx in test_indices]
+
+    return X_train, X_test, y_train, y_test
+
+
+def evaluate_predictions(y_true: List[List[float]], y_pred: List[List[float]]) -> dict[str, float]:
+    n_samples = len(y_true)
+    n_targets = len(y_true[0]) if y_true else 0
+
+    mse_sum = 0.0
+    mae_sum = 0.0
+    target_means = [0.0 for _ in range(n_targets)]
+
+    for sample in y_true:
+        for idx, value in enumerate(sample):
+            target_means[idx] += value
+    target_means = [value / n_samples for value in target_means]
+
+    ss_tot = [0.0 for _ in range(n_targets)]
+    ss_res = [0.0 for _ in range(n_targets)]
+
+    for true_sample, pred_sample in zip(y_true, y_pred):
+        for idx, (true_value, pred_value) in enumerate(zip(true_sample, pred_sample)):
+            diff = true_value - pred_value
+            mse_sum += diff * diff
+            mae_sum += abs(diff)
+            ss_res[idx] += diff * diff
+            centered = true_value - target_means[idx]
+            ss_tot[idx] += centered * centered
+
+    mse = mse_sum / (n_samples * n_targets)
+    rmse = math.sqrt(mse)
+    mae = mae_sum / (n_samples * n_targets)
+
+    r2_values = []
+    for idx in range(n_targets):
+        if ss_tot[idx] == 0.0:
+            r2_values.append(0.0)
+        else:
+            r2_values.append(1 - ss_res[idx] / ss_tot[idx])
+    r2 = sum(r2_values) / n_targets if r2_values else 0.0
+
+    return {"rmse": rmse, "mae": mae, "r2": r2}
+
+
+def parse_hidden_layers(raw: Sequence[str]) -> Sequence[int]:
+    try:
+        layers = tuple(int(value) for value in raw)
+    except ValueError as exc:  # pragma: no cover
+        raise argparse.ArgumentTypeError("Camadas ocultas devem ser números inteiros.") from exc
+
+    if not layers:
+        raise argparse.ArgumentTypeError("É necessário informar pelo menos uma camada oculta.")
+
+    if any(size <= 0 for size in layers):
+        raise argparse.ArgumentTypeError("Os tamanhos das camadas devem ser positivos.")
+
+    return layers
+
+
+def run(
+    data_dir: Path,
+    hidden_layers: Sequence[int],
+    learning_rate: float,
+    epochs: int,
+    batch_size: int,
+    test_size: float,
+    random_state: int,
+    output_predictions: Path | None,
+) -> dict[str, float]:
+    dataset = read_feature_folds(data_dir)
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        dataset.features,
+        dataset.targets,
+        test_size=test_size,
+        random_state=random_state,
+    )
+
+    model = DeepMLPRegressor(
+        hidden_layers=hidden_layers,
+        learning_rate=learning_rate,
+        epochs=epochs,
+        batch_size=batch_size,
+        random_state=random_state,
+    )
+    model.fit(X_train, y_train)
+
+    y_pred = model.predict(X_test)
+    metrics = evaluate_predictions(y_test, y_pred)
+
+    if output_predictions is not None:
+        output_predictions.parent.mkdir(parents=True, exist_ok=True)
+        with output_predictions.open("w", newline="") as handle:
+            writer = csv.writer(handle)
+            writer.writerow([f"pred_{name}" for name in dataset.target_names])
+            for row in y_pred:
+                writer.writerow(row)
+
+    return metrics
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=Path("features"),
+        help="Pasta contendo os arquivos features_y_fold*.csv.",
+    )
+    parser.add_argument(
+        "--hidden-layers",
+        type=parse_hidden_layers,
+        nargs="+",
+        default=(128, 64, 32),
+        help="Tamanhos das camadas ocultas da MLP (default: 128 64 32).",
+    )
+    parser.add_argument(
+        "--learning-rate",
+        type=float,
+        default=5e-3,
+        help="Taxa de aprendizado do otimizador Adam.",
+    )
+    parser.add_argument(
+        "--epochs",
+        type=int,
+        default=50,
+        help="Número de épocas de treinamento.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=128,
+        help="Tamanho do mini-batch durante o treinamento.",
+    )
+    parser.add_argument(
+        "--test-size",
+        type=float,
+        default=0.2,
+        help="Proporção dos dados destinada ao conjunto de teste.",
+    )
+    parser.add_argument(
+        "--random-state",
+        type=int,
+        default=42,
+        help="Semente de aleatoriedade para reprodutibilidade.",
+    )
+    parser.add_argument(
+        "--output-predictions",
+        type=Path,
+        default=None,
+        help="Caminho para salvar as previsões (opcional).",
+    )
+
+    args = parser.parse_args(argv)
+    metrics = run(
+        data_dir=args.data_dir,
+        hidden_layers=args.hidden_layers,
+        learning_rate=args.learning_rate,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        test_size=args.test_size,
+        random_state=args.random_state,
+        output_predictions=args.output_predictions,
+    )
+
+    print("Desempenho do regressor profundo:")
+    for name, value in metrics.items():
+        if name == "r2":
+            print(f"- {name.upper()}: {value:.4f}")
+        else:
+            print(f"- {name.upper()}: {value:.6f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a deep MLP regression section to the notebook to learn quantum features from classical inputs
- integrate the deep regressor predictions into the gradient boosting evaluation, refreshed metric tables, plots, and prediction previews

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d6fb382e7883318703403063906391