### PR TITLE
Add multi-model comparison section to gradient boosting notebook

### DIFF
--- a/Gradient_Boosting_Comparison.ipynb
+++ b/Gradient_Boosting_Comparison.ipynb
@@ -444,6 +444,42 @@
    "source": [
     "dl_predictions = predictions_df[predictions_df['model'] == 'Quantum (Deep MLP)']\ndl_predictions.head()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Comparação de algoritmos clássicos\nPara investigar se outros classificadores conseguem aproveitar as features expandidas pelo regressor profundo, treinamos uma coleção de modelos tradicionais utilizando o mesmo conjunto de atributos (`classical` + previsões do MLP)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from sklearn.base import clone\nfrom sklearn.linear_model import LogisticRegression\nfrom sklearn.neighbors import KNeighborsClassifier\nfrom sklearn.svm import SVC\nfrom sklearn.ensemble import RandomForestClassifier\nfrom sklearn.neural_network import MLPClassifier\nfrom sklearn.pipeline import Pipeline\nfrom sklearn.preprocessing import StandardScaler\n\nalgorithm_estimators = {\n    \"Logistic Regression\": Pipeline([\n        (\"scaler\", StandardScaler()),\n        (\"model\", LogisticRegression(max_iter=1000, random_state=42)),\n    ]),\n    \"KNN (k=15)\": Pipeline([\n        (\"scaler\", StandardScaler()),\n        (\"model\", KNeighborsClassifier(n_neighbors=15)),\n    ]),\n    \"SVM (RBF)\": Pipeline([\n        (\"scaler\", StandardScaler()),\n        (\"model\", SVC(kernel=\"rbf\", probability=True, random_state=42)),\n    ]),\n    \"Random Forest\": RandomForestClassifier(n_estimators=300, random_state=42),\n    \"Gradient Boosting\": GradientBoostingClassifier(random_state=42),\n    \"MLP Classifier\": Pipeline([\n        (\"scaler\", StandardScaler()),\n        (\n            \"model\",\n            MLPClassifier(\n                hidden_layer_sizes=(128, 64),\n                activation=\"relu\",\n                max_iter=1000,\n                random_state=42,\n            ),\n        ),\n    ]),\n}\n\nalgo_results = []\nalgo_prediction_frames = []\n\nfor fold_idx, fold_df in enumerate(fold_frames):\n    train_df = fold_df[fold_df[\"set\"] == \"train\"]\n    test_df = fold_df[fold_df[\"set\"] == \"test\"]\n    y_train = train_df[\"y\"]\n    y_test = test_df[\"y\"]\n    X_train = train_df[dl_feature_set]\n    X_test = test_df[dl_feature_set]\n\n    for model_name, estimator in algorithm_estimators.items():\n        model = clone(estimator)\n        model.fit(X_train, y_train)\n        y_proba = model.predict_proba(X_test)[:, 1]\n        y_pred = model.predict(X_test)\n\n        for metric_name, metric_fn in metric_functions.items():\n            value = metric_fn(y_test, y_proba, y_pred)\n            algo_results.append(\n                {\n                    \"fold\": fold_idx,\n                    \"fold_name\": fold_df[\"fold_name\"].iat[0],\n                    \"model\": model_name,\n                    \"metric\": metric_name,\n                    \"value\": value,\n                }\n            )\n\n        algo_prediction_frames.append(\n            pd.DataFrame(\n                {\n                    \"fold\": fold_idx,\n                    \"fold_name\": fold_df[\"fold_name\"].iat[0],\n                    \"row_id\": test_df[\"row_id\"].values,\n                    \"y_true\": y_test.values,\n                    \"model\": model_name,\n                    \"y_pred\": y_pred,\n                    \"y_proba\": y_proba,\n                }\n            )\n        )\n\nalgo_results_df = pd.DataFrame(algo_results)\nalgo_predictions_df = pd.concat(algo_prediction_frames, ignore_index=True)\nalgo_results_df.head()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Métricas agregadas\nAgregamos as métricas por algoritmo calculando a mediana e o intervalo interquartil ao longo dos *folds*."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "algo_metrics_summary = (\n    algo_results_df\n    .groupby([\"model\", \"metric\"])[\"value\"]\n    .agg(\n        median=lambda s: np.nanmedian(s),\n        q1=lambda s: np.nanquantile(s, 0.25),\n        q3=lambda s: np.nanquantile(s, 0.75),\n    )\n    .reset_index()\n)\nalgo_metrics_summary[\"iqr\"] = algo_metrics_summary[\"q3\"] - algo_metrics_summary[\"q1\"]\nalgo_metrics_summary[\"median_iqr\"] = algo_metrics_summary.apply(\n    lambda row: f\"{row['median']:.4f} [{row['q1']:.4f}, {row['q3']:.4f}]\",\n    axis=1,\n)\nalgo_metrics_summary\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Comparação visual\nO gráfico abaixo mostra, para as principais métricas de classificação, a mediana obtida por cada algoritmo ao longo dos *folds*."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "key_metrics = [\"AUC\", \"F1 Score Overall\", \"Balanced Accuracy\"]\nplot_data = algo_metrics_summary[algo_metrics_summary[\"metric\"].isin(key_metrics)]\nplt.figure(figsize=(12, 6))\nsns.barplot(data=plot_data, x=\"metric\", y=\"median\", hue=\"model\")\nplt.ylabel(\"Mediana\")\nplt.xlabel(\"Métrica\")\nplt.title(\"Desempenho por algoritmo (features clássicas + DL)\")\nplt.legend(title=\"Algoritmo\", bbox_to_anchor=(1.05, 1), loc=\"upper left\")\nplt.tight_layout()\n"
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- add a new section that evaluates several traditional classifiers on the deep-learning-enhanced feature set
- report aggregated performance metrics per algorithm to compare their robustness across folds
- visualize the algorithm comparison with a grouped bar chart for key classification metrics

## Testing
- not run (notebook change only)


------
https://chatgpt.com/codex/tasks/task_b_68d7f48107f88331bcf5acf49d4b4ef0