### PR TITLE
Restore GradientBoostingClassifier in toxicity notebook

### DIFF
--- a/01_hist_gradient_boosting.ipynb
+++ b/01_hist_gradient_boosting.ipynb
@@ -4,20 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Predi\u00e7\u00e3o com HistGradientBoostingRegressor\n",
+    "# Predição com GradientBoostingClassifier\n",
     "\n",
-    "Este notebook carrega os *folds* dispon\u00edveis na pasta `features/`, treina modelos de Gradient Boosting usando apenas as features cl\u00e1ssicas (`class_0` a `class_12`) e o conjunto combinado de features cl\u00e1ssicas + qu\u00e2nticas (`qf_0` a `qf_12`).\n",
+    "Este notebook carrega os *folds* disponíveis na pasta `features/`, treina modelos de Gradient Boosting usando apenas as features clássicas (`class_0` a `class_12`) e o conjunto combinado de features clássicas + quânticas (`qf_0` a `qf_12`).\n",
     "\n",
-    "Al\u00e9m disso, inclu\u00edmos um `HistGradientBoostingRegressor` para aproximar as features qu\u00e2nticas a partir das cl\u00e1ssicas e avaliamos o impacto dessas estimativas no desempenho do classificador.\n"
+    "Além disso, incluímos um `HistGradientBoostingRegressor` para aproximar as features quânticas a partir das clássicas e avaliamos o impacto dessas estimativas no desempenho do classificador.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Depend\u00eancias\n",
+    "## Dependências\n",
     "\n",
-    "O notebook utiliza `pandas`, `numpy`, `scikit-learn`, `matplotlib` e `seaborn`. Caso ainda n\u00e3o as tenha instalado no seu ambiente, execute o comando abaixo em uma c\u00e9lula separada ou diretamente no terminal:\n",
+    "O notebook utiliza `pandas`, `numpy`, `scikit-learn`, `matplotlib` e `seaborn`. Caso ainda não as tenha instalado no seu ambiente, execute o comando abaixo em uma célula separada ou diretamente no terminal:\n",
     "\n",
     "```bash\n",
     "pip install pandas numpy scikit-learn matplotlib seaborn\n",
@@ -37,7 +37,7 @@
     "import seaborn as sns\n",
     "from IPython.display import display\n",
     "from matplotlib import pyplot as plt\n",
-    "from sklearn.ensemble import HistGradientBoostingClassifier, HistGradientBoostingRegressor\n",
+    "from sklearn.ensemble import GradientBoostingClassifier, HistGradientBoostingRegressor\n",
     "from sklearn.model_selection import ParameterGrid\n",
     "from sklearn.metrics import (\n",
     "    balanced_accuracy_score,\n",
@@ -51,7 +51,7 @@
     ")\n",
     "from sklearn.multioutput import MultiOutputRegressor\n",
     "\n",
-    "# Configura\u00e7\u00e3o est\u00e9tica padr\u00e3o para os gr\u00e1ficos\n",
+    "# Configuração estética padrão para os gráficos\n",
     "sns.set_style(\"whitegrid\")\n",
     "plt.rcParams.update({\"figure.figsize\": (10, 5), \"axes.titlesize\": 14, \"axes.labelsize\": 12})\n",
     "\n",
@@ -99,9 +99,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Defini\u00e7\u00e3o dos grupos de features e fun\u00e7\u00e3o de avalia\u00e7\u00e3o\n",
+    "## Definição dos grupos de features e função de avaliação\n",
     "\n",
-    "A fun\u00e7\u00e3o abaixo treina um `GradientBoostingClassifier` para cada conjunto de features em todos os *folds*, calcula as m\u00e9tricas desejadas no conjunto de teste e armazena as predi\u00e7\u00f5es geradas.\n"
+    "A função abaixo treina um `GradientBoostingClassifier` para cada conjunto de features em todos os *folds*, calcula as métricas desejadas no conjunto de teste e armazena as predições geradas.\n"
    ]
   },
   {
@@ -113,7 +113,7 @@
     "classical_features = [col for col in fold_frames[0].columns if col.startswith(\"class_\")]\n",
     "quantum_features = [col for col in fold_frames[0].columns if col.startswith(\"qf_\")]\n",
     "\n",
-    "# Treinamento do regressor qu\u00e2ntico \u00e9 realizado separadamente em cada fold usando apenas os dados de treino\n",
+    "# Treinamento do regressor quântico é realizado separadamente em cada fold usando apenas os dados de treino\n",
     "predicted_quantum_features = [f\"pred_{feature}\" for feature in quantum_features]\n",
     "\n",
     "for fold_df in fold_frames:\n",
@@ -158,7 +158,7 @@
     "        X_train = train_df[columns]\n",
     "        X_test = test_df[columns]\n",
     "\n",
-    "        model = HistGradientBoostingClassifier(random_state=42)\n",
+    "        model = GradientBoostingClassifier(random_state=42)\n",
     "        model.fit(X_train, y_train)\n",
     "\n",
     "        y_proba = model.predict_proba(X_test)[:, 1]\n",
@@ -184,9 +184,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Resumo das m\u00e9tricas por modelo\n",
+    "## Resumo das métricas por modelo\n",
     "\n",
-    "A tabela a seguir mostra a mediana e o intervalo interquartil (25%-75%) das m\u00e9tricas em todos os *folds*.\n"
+    "A tabela a seguir mostra a mediana e o intervalo interquartil (25%-75%) das métricas em todos os *folds*.\n"
    ]
   },
   {
@@ -217,9 +217,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Gr\u00e1fico comparativo\n",
+    "## Gráfico comparativo\n",
     "\n",
-    "O gr\u00e1fico reproduz o exemplo solicitado, com barras pretas representando o benchmark (apenas features cl\u00e1ssicas) e barras amarelas representando o modelo com features cl\u00e1ssicas + qu\u00e2nticas. Os valores exibidos nas barras correspondem \u00e0s medianas por *fold*.\n"
+    "O gráfico reproduz o exemplo solicitado, com barras pretas representando o benchmark (apenas features clássicas) e barras amarelas representando o modelo com features clássicas + quânticas. Os valores exibidos nas barras correspondem às medianas por *fold*.\n"
    ]
   },
   {
@@ -276,9 +276,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Busca de hiperpar\u00e2metros\n",
+    "## Busca de hiperparâmetros\n",
     "\n",
-    "Realizamos uma busca em grade simples para o `HistGradientBoostingClassifier` utilizando o conjunto de features \"Quantum (Regressor)\". Cada combina\u00e7\u00e3o \u00e9 avaliada pela m\u00e9trica de AUC considerando todos os *folds* dispon\u00edveis.\n"
+    "Realizamos uma busca em grade simples para o `GradientBoostingClassifier` utilizando o conjunto de features \"Quantum (Regressor)\". Cada combinação é avaliada pela métrica de AUC considerando todos os *folds* disponíveis.\n"
    ]
   },
   {
@@ -290,9 +290,9 @@
     "search_feature_set = \"Quantum (Regressor)\"\n",
     "param_grid = {\n",
     "    \"learning_rate\": [0.05, 0.1],\n",
-    "    \"max_leaf_nodes\": [31, 63],\n",
+    "    \"n_estimators\": [200, 400],\n",
+    "    \"max_depth\": [3, 5],\n",
     "    \"min_samples_leaf\": [20, 40],\n",
-    "    \"max_iter\": [200, 400],\n",
     "}\n",
     "\n",
     "search_results = []\n",
@@ -303,7 +303,7 @@
     "        train_df = fold_df[fold_df[\"set\"] == \"train\"]\n",
     "        test_df = fold_df[fold_df[\"set\"] == \"test\"]\n",
     "\n",
-    "        model = HistGradientBoostingClassifier(random_state=42, **params)\n",
+    "        model = GradientBoostingClassifier(random_state=42, **params)\n",
     "        model.fit(train_df[feature_sets[search_feature_set]], train_df[\"y\"])\n",
     "\n",
     "        y_proba = model.predict_proba(test_df[feature_sets[search_feature_set]])[:, 1]\n",


### PR DESCRIPTION
## Summary
- revert the notebook narrative to describe GradientBoostingClassifier while retaining the HistGradientBoostingRegressor for quantum feature approximation
- switch the training loops and hyperparameter search back to GradientBoostingClassifier with an appropriate parameter grid

## Testing
- not run (notebook-only changes)

------
https://chatgpt.com/codex/tasks/task_b_68d8047e83fc833188bbf3d9eb1edae7